### PR TITLE
chore: update node dependencies hash

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -69,7 +69,7 @@
 
           outputHashMode = "recursive";
           outputHashAlgo = "sha256";
-          outputHash = "sha256-ZwE9ZoRfSdAcn66ouBuOz295k/krqN2rO1nZWZHvGUE=";
+          outputHash = "sha256-uA3IXiJWqpoGI4djdoISP2Gp736XZjSKnTe1n97Tj6E=";
         };
 
       in


### PR DESCRIPTION
## Automated Hash Update

This PR updates the node dependencies hash in `flake.nix`.

**New hash:** `sha256-uA3IXiJWqpoGI4djdoISP2Gp736XZjSKnTe1n97Tj6E=`

Generated by the release-please-hash-updater workflow.